### PR TITLE
Add UTM GPS wrapper

### DIFF
--- a/src/gps_odom/CMakeLists.txt
+++ b/src/gps_odom/CMakeLists.txt
@@ -1,0 +1,195 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(gps_odom)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED roscpp sensor_msgs)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES gps_odom
+#  CATKIN_DEPENDS other_catkin_pkg
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+ include
+ ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/gps_odom.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+add_executable(${PROJECT_NAME}_node src/gps_odom_node.cpp src/gps_odom.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(${PROJECT_NAME}_node
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_gps_odom.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/src/gps_odom/CMakeLists.txt
+++ b/src/gps_odom/CMakeLists.txt
@@ -7,7 +7,7 @@ add_compile_options(-std=c++11)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED roscpp sensor_msgs)
+find_package(catkin REQUIRED roscpp sensor_msgs geometry_msgs tf2 tf2_ros)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/src/gps_odom/package.xml
+++ b/src/gps_odom/package.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>gps_odom</name>
+  <version>0.0.0</version>
+  <description>The gps_odom package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="ras@pitt.edu">Pitt Robotics and Automation Society</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/gps_odom</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/src/gps_odom/src/conversions.h
+++ b/src/gps_odom/src/conversions.h
@@ -1,0 +1,289 @@
+/* Taken from utexas-art-ros-pkg:art_vehicle/applanix */
+
+/*
+ * Conversions between coordinate systems.
+ *
+ * Includes LatLong<->UTM.
+ */
+
+#ifndef _UTM_H
+#define _UTM_H
+
+/**  @file
+
+     @brief Universal Transverse Mercator transforms.
+
+     Functions to convert (spherical) latitude and longitude to and
+     from (Euclidean) UTM coordinates.
+
+     @author Chuck Gantz- chuck.gantz@globalstar.com
+
+ */
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+
+namespace gps_common
+{
+
+const double RADIANS_PER_DEGREE = M_PI/180.0;
+const double DEGREES_PER_RADIAN = 180.0/M_PI;
+
+// WGS84 Parameters
+const double WGS84_A = 6378137.0;		// major axis
+const double WGS84_B = 6356752.31424518;	// minor axis
+const double WGS84_F = 0.0033528107;		// ellipsoid flattening
+const double WGS84_E = 0.0818191908;		// first eccentricity
+const double WGS84_EP = 0.0820944379;		// second eccentricity
+
+// UTM Parameters
+const double UTM_K0 = 0.9996;			// scale factor
+const double UTM_FE = 500000.0;		// false easting
+const double UTM_FN_N = 0.0;			// false northing on north hemisphere
+const double UTM_FN_S = 10000000.0;		// false northing on south hemisphere
+const double UTM_E2 = (WGS84_E*WGS84_E);	// e^2
+const double UTM_E4 = (UTM_E2*UTM_E2);		// e^4
+const double UTM_E6 = (UTM_E4*UTM_E2);		// e^6
+const double UTM_EP2 = (UTM_E2/(1-UTM_E2));	// e'^2
+
+/**
+ * Utility function to convert geodetic to UTM position
+ *
+ * Units in are floating point degrees (sign for east/west)
+ *
+ * Units out are meters
+ */
+static inline void UTM(double lat, double lon, double *x, double *y)
+{
+  // constants
+  const static double m0 = (1 - UTM_E2/4 - 3*UTM_E4/64 - 5*UTM_E6/256);
+  const static double m1 = -(3*UTM_E2/8 + 3*UTM_E4/32 + 45*UTM_E6/1024);
+  const static double m2 = (15*UTM_E4/256 + 45*UTM_E6/1024);
+  const static double m3 = -(35*UTM_E6/3072);
+
+  // compute the central meridian
+  int cm = ((lon >= 0.0)
+	    ? ((int)lon - ((int)lon)%6 + 3)
+	    : ((int)lon - ((int)lon)%6 - 3));
+
+  // convert degrees into radians
+  double rlat = lat * RADIANS_PER_DEGREE;
+  double rlon = lon * RADIANS_PER_DEGREE;
+  double rlon0 = cm * RADIANS_PER_DEGREE;
+
+  // compute trigonometric functions
+  double slat = sin(rlat);
+  double clat = cos(rlat);
+  double tlat = tan(rlat);
+
+  // decide the false northing at origin
+  double fn = (lat > 0) ? UTM_FN_N : UTM_FN_S;
+
+  double T = tlat * tlat;
+  double C = UTM_EP2 * clat * clat;
+  double A = (rlon - rlon0) * clat;
+  double M = WGS84_A * (m0*rlat + m1*sin(2*rlat)
+			+ m2*sin(4*rlat) + m3*sin(6*rlat));
+  double V = WGS84_A / sqrt(1 - UTM_E2*slat*slat);
+
+  // compute the easting-northing coordinates
+  *x = UTM_FE + UTM_K0 * V * (A + (1-T+C)*pow(A,3)/6
+			      + (5-18*T+T*T+72*C-58*UTM_EP2)*pow(A,5)/120);
+  *y = fn + UTM_K0 * (M + V * tlat * (A*A/2
+				      + (5-T+9*C+4*C*C)*pow(A,4)/24
+				      + ((61-58*T+T*T+600*C-330*UTM_EP2)
+					 * pow(A,6)/720)));
+
+  return;
+}
+
+
+/**
+ * Determine the correct UTM letter designator for the
+ * given latitude
+ *
+ * @returns 'Z' if latitude is outside the UTM limits of 84N to 80S
+ *
+ * Written by Chuck Gantz- chuck.gantz@globalstar.com
+ */
+static inline char UTMLetterDesignator(double Lat)
+{
+	char LetterDesignator;
+
+	if     ((84 >= Lat) && (Lat >= 72))  LetterDesignator = 'X';
+	else if ((72 > Lat) && (Lat >= 64))  LetterDesignator = 'W';
+	else if ((64 > Lat) && (Lat >= 56))  LetterDesignator = 'V';
+	else if ((56 > Lat) && (Lat >= 48))  LetterDesignator = 'U';
+	else if ((48 > Lat) && (Lat >= 40))  LetterDesignator = 'T';
+	else if ((40 > Lat) && (Lat >= 32))  LetterDesignator = 'S';
+	else if ((32 > Lat) && (Lat >= 24))  LetterDesignator = 'R';
+	else if ((24 > Lat) && (Lat >= 16))  LetterDesignator = 'Q';
+	else if ((16 > Lat) && (Lat >= 8))   LetterDesignator = 'P';
+	else if (( 8 > Lat) && (Lat >= 0))   LetterDesignator = 'N';
+	else if (( 0 > Lat) && (Lat >= -8))  LetterDesignator = 'M';
+	else if ((-8 > Lat) && (Lat >= -16)) LetterDesignator = 'L';
+	else if((-16 > Lat) && (Lat >= -24)) LetterDesignator = 'K';
+	else if((-24 > Lat) && (Lat >= -32)) LetterDesignator = 'J';
+	else if((-32 > Lat) && (Lat >= -40)) LetterDesignator = 'H';
+	else if((-40 > Lat) && (Lat >= -48)) LetterDesignator = 'G';
+	else if((-48 > Lat) && (Lat >= -56)) LetterDesignator = 'F';
+	else if((-56 > Lat) && (Lat >= -64)) LetterDesignator = 'E';
+	else if((-64 > Lat) && (Lat >= -72)) LetterDesignator = 'D';
+	else if((-72 > Lat) && (Lat >= -80)) LetterDesignator = 'C';
+        // 'Z' is an error flag, the Latitude is outside the UTM limits
+	else LetterDesignator = 'Z';
+	return LetterDesignator;
+}
+
+/**
+ * Convert lat/long to UTM coords.  Equations from USGS Bulletin 1532
+ *
+ * East Longitudes are positive, West longitudes are negative.
+ * North latitudes are positive, South latitudes are negative
+ * Lat and Long are in fractional degrees
+ *
+ * Written by Chuck Gantz- chuck.gantz@globalstar.com
+ */
+static inline void LLtoUTM(const double Lat, const double Long,
+                           double &UTMNorthing, double &UTMEasting,
+                           char* UTMZone)
+{
+	double a = WGS84_A;
+	double eccSquared = UTM_E2;
+	double k0 = UTM_K0;
+
+	double LongOrigin;
+	double eccPrimeSquared;
+	double N, T, C, A, M;
+
+        //Make sure the longitude is between -180.00 .. 179.9
+	double LongTemp = (Long+180)-int((Long+180)/360)*360-180;
+
+	double LatRad = Lat*RADIANS_PER_DEGREE;
+	double LongRad = LongTemp*RADIANS_PER_DEGREE;
+	double LongOriginRad;
+	int    ZoneNumber;
+
+	ZoneNumber = int((LongTemp + 180)/6) + 1;
+
+	if( Lat >= 56.0 && Lat < 64.0 && LongTemp >= 3.0 && LongTemp < 12.0 )
+		ZoneNumber = 32;
+
+        // Special zones for Svalbard
+	if( Lat >= 72.0 && Lat < 84.0 )
+	{
+	  if(      LongTemp >= 0.0  && LongTemp <  9.0 ) ZoneNumber = 31;
+	  else if( LongTemp >= 9.0  && LongTemp < 21.0 ) ZoneNumber = 33;
+	  else if( LongTemp >= 21.0 && LongTemp < 33.0 ) ZoneNumber = 35;
+	  else if( LongTemp >= 33.0 && LongTemp < 42.0 ) ZoneNumber = 37;
+	 }
+        // +3 puts origin in middle of zone
+	LongOrigin = (ZoneNumber - 1)*6 - 180 + 3;
+	LongOriginRad = LongOrigin * RADIANS_PER_DEGREE;
+
+	//compute the UTM Zone from the latitude and longitude
+	snprintf(UTMZone, 4, "%d%c", ZoneNumber, UTMLetterDesignator(Lat));
+
+	eccPrimeSquared = (eccSquared)/(1-eccSquared);
+
+	N = a/sqrt(1-eccSquared*sin(LatRad)*sin(LatRad));
+	T = tan(LatRad)*tan(LatRad);
+	C = eccPrimeSquared*cos(LatRad)*cos(LatRad);
+	A = cos(LatRad)*(LongRad-LongOriginRad);
+
+	M = a*((1	- eccSquared/4		- 3*eccSquared*eccSquared/64	- 5*eccSquared*eccSquared*eccSquared/256)*LatRad
+				- (3*eccSquared/8	+ 3*eccSquared*eccSquared/32	+ 45*eccSquared*eccSquared*eccSquared/1024)*sin(2*LatRad)
+									+ (15*eccSquared*eccSquared/256 + 45*eccSquared*eccSquared*eccSquared/1024)*sin(4*LatRad)
+									- (35*eccSquared*eccSquared*eccSquared/3072)*sin(6*LatRad));
+
+	UTMEasting = (double)(k0*N*(A+(1-T+C)*A*A*A/6
+					+ (5-18*T+T*T+72*C-58*eccPrimeSquared)*A*A*A*A*A/120)
+					+ 500000.0);
+
+	UTMNorthing = (double)(k0*(M+N*tan(LatRad)*(A*A/2+(5-T+9*C+4*C*C)*A*A*A*A/24
+				 + (61-58*T+T*T+600*C-330*eccPrimeSquared)*A*A*A*A*A*A/720)));
+	if(Lat < 0)
+		UTMNorthing += 10000000.0; //10000000 meter offset for southern hemisphere
+}
+
+static inline void LLtoUTM(const double Lat, const double Long,
+                           double &UTMNorthing, double &UTMEasting,
+                           std::string &UTMZone) {
+  char zone_buf[] = {0, 0, 0, 0};
+
+  LLtoUTM(Lat, Long, UTMNorthing, UTMEasting, zone_buf);
+
+  UTMZone = zone_buf;
+}
+
+
+/**
+ * Converts UTM coords to lat/long.  Equations from USGS Bulletin 1532
+ *
+ * East Longitudes are positive, West longitudes are negative.
+ * North latitudes are positive, South latitudes are negative
+ * Lat and Long are in fractional degrees.
+ *
+ * Written by Chuck Gantz- chuck.gantz@globalstar.com
+ */
+static inline void UTMtoLL(const double UTMNorthing, const double UTMEasting,
+                           const char* UTMZone, double& Lat,  double& Long )
+{
+	double k0 = UTM_K0;
+	double a = WGS84_A;
+	double eccSquared = UTM_E2;
+	double eccPrimeSquared;
+	double e1 = (1-sqrt(1-eccSquared))/(1+sqrt(1-eccSquared));
+	double N1, T1, C1, R1, D, M;
+	double LongOrigin;
+	double mu, phi1Rad;
+	double x, y;
+	int ZoneNumber;
+	char* ZoneLetter;
+
+	x = UTMEasting - 500000.0; //remove 500,000 meter offset for longitude
+	y = UTMNorthing;
+
+	ZoneNumber = strtoul(UTMZone, &ZoneLetter, 10);
+	if((*ZoneLetter - 'N') < 0)
+	{
+		y -= 10000000.0;//remove 10,000,000 meter offset used for southern hemisphere
+	}
+
+	LongOrigin = (ZoneNumber - 1)*6 - 180 + 3;  //+3 puts origin in middle of zone
+
+	eccPrimeSquared = (eccSquared)/(1-eccSquared);
+
+	M = y / k0;
+	mu = M/(a*(1-eccSquared/4-3*eccSquared*eccSquared/64-5*eccSquared*eccSquared*eccSquared/256));
+
+	phi1Rad = mu	+ (3*e1/2-27*e1*e1*e1/32)*sin(2*mu)
+				+ (21*e1*e1/16-55*e1*e1*e1*e1/32)*sin(4*mu)
+				+(151*e1*e1*e1/96)*sin(6*mu);
+
+	N1 = a/sqrt(1-eccSquared*sin(phi1Rad)*sin(phi1Rad));
+	T1 = tan(phi1Rad)*tan(phi1Rad);
+	C1 = eccPrimeSquared*cos(phi1Rad)*cos(phi1Rad);
+	R1 = a*(1-eccSquared)/pow(1-eccSquared*sin(phi1Rad)*sin(phi1Rad), 1.5);
+	D = x/(N1*k0);
+
+	Lat = phi1Rad - (N1*tan(phi1Rad)/R1)*(D*D/2-(5+3*T1+10*C1-4*C1*C1-9*eccPrimeSquared)*D*D*D*D/24
+					+(61+90*T1+298*C1+45*T1*T1-252*eccPrimeSquared-3*C1*C1)*D*D*D*D*D*D/720);
+	Lat = Lat * DEGREES_PER_RADIAN;
+
+	Long = (D-(1+2*T1+C1)*D*D*D/6+(5-2*C1+28*T1-3*C1*C1+8*eccPrimeSquared+24*T1*T1)
+					*D*D*D*D*D/120)/cos(phi1Rad);
+	Long = LongOrigin + Long * DEGREES_PER_RADIAN;
+
+}
+
+static inline void UTMtoLL(const double UTMNorthing, const double UTMEasting,
+    std::string UTMZone, double& Lat, double& Long) {
+  UTMtoLL(UTMNorthing, UTMEasting, UTMZone.c_str(), Lat, Long);
+}
+
+} // end namespace UTM
+
+#endif // _UTM_H
+

--- a/src/gps_odom/src/gps_odom.cpp
+++ b/src/gps_odom/src/gps_odom.cpp
@@ -1,0 +1,34 @@
+#include "gps_odom.h"
+#include "conversions.h"
+
+GPSOdom::GPSOdom(ros::NodeHandle& nh) : 
+    originSet(false),
+    gpsSub(nh.subscribe<sensor_msgs::NavSatFix>("fix", 10, &GPSOdom::updateFix, this)),
+    imuSub(nh.subscribe<sensor_msgs::Imu>("imu", 10, &GPSOdom::updateImu, this)),
+    odomPub(nh.advertise<nav_msgs::Odometry>("odometry/gps/raw", 10)) {
+}
+
+void GPSOdom::updateFix(const sensor_msgs::NavSatFix::ConstPtr& fix) {
+    double northing, easting;
+    std::string zone;
+    gps_common::LLtoUTM(fix->latitude, fix->longitude, northing, easting, zone);
+
+    if ( !originSet ) {
+        originX = easting;
+        originY = northing;
+        originSet = true;
+        ROS_WARN("GPSOdom set origin - received first GPS message");
+    }
+
+    odom_msg.pose.pose.position.x = easting-originX;
+    odom_msg.pose.pose.position.y = northing-originY;
+}
+
+void GPSOdom::updateImu(const sensor_msgs::Imu::ConstPtr& imu) {
+    odom_msg.pose.pose.orientation = imu->orientation;
+}
+
+void GPSOdom::update() {
+    odomPub.publish(odom_msg);
+}
+

--- a/src/gps_odom/src/gps_odom.cpp
+++ b/src/gps_odom/src/gps_odom.cpp
@@ -1,11 +1,24 @@
 #include "gps_odom.h"
 #include "conversions.h"
 
-GPSOdom::GPSOdom(ros::NodeHandle& nh) : 
+GPSOdom::GPSOdom(ros::NodeHandle& nh) :
     originSet(false),
     gpsSub(nh.subscribe<sensor_msgs::NavSatFix>("fix", 10, &GPSOdom::updateFix, this)),
     imuSub(nh.subscribe<sensor_msgs::Imu>("imu", 10, &GPSOdom::updateImu, this)),
-    odomPub(nh.advertise<nav_msgs::Odometry>("odometry/gps/raw", 10)) {
+    velSub(nh.subscribe<geometry_msgs::TwistStamped>("vel", 10, &GPSOdom::updateVel, this)),
+    odomPub(nh.advertise<nav_msgs::Odometry>("odometry/gps/raw", 10)),
+    odom_frame("odom"),
+    base_link_frame("boat"),
+    utm_frame("utm") {
+
+    transform.header.frame_id = odom_frame;
+    transform.child_frame_id = base_link_frame;
+
+    geometry_msgs::Quaternion zeroQuat;
+    zeroQuat.x = zeroQuat.y = zeroQuat.z = 0;
+    zeroQuat.w = 1;
+
+    transform.transform.rotation = zeroQuat;
 }
 
 void GPSOdom::updateFix(const sensor_msgs::NavSatFix::ConstPtr& fix) {
@@ -22,10 +35,24 @@ void GPSOdom::updateFix(const sensor_msgs::NavSatFix::ConstPtr& fix) {
 
     odom_msg.pose.pose.position.x = easting-originX;
     odom_msg.pose.pose.position.y = northing-originY;
+
+    geometry_msgs::Vector3 position;
+    position.x = odom_msg.pose.pose.position.x;
+    position.y = odom_msg.pose.pose.position.y;
+    position.z = 0;
+    transform.transform.translation = position;
+
+    transform.header.stamp = ros::Time::now();
+    transform_broadcaster.sendTransform(transform);
 }
 
 void GPSOdom::updateImu(const sensor_msgs::Imu::ConstPtr& imu) {
     odom_msg.pose.pose.orientation = imu->orientation;
+    transform.transform.rotation = imu->orientation;
+}
+
+void GPSOdom::updateVel(const geometry_msgs::TwistStamped::ConstPtr& twist) {
+    odom_msg.twist.twist = twist->twist;
 }
 
 void GPSOdom::update() {

--- a/src/gps_odom/src/gps_odom.cpp
+++ b/src/gps_odom/src/gps_odom.cpp
@@ -11,6 +11,10 @@ GPSOdom::GPSOdom(ros::NodeHandle& nh) :
     base_link_frame("boat"),
     utm_frame("utm") {
 
+    nh.param<std::string>("odom_frame", odom_frame, "odom");
+    nh.param<std::string>("boat_frame", base_link_frame, "boat");
+    nh.param<std::string>("utm_frame", utm_frame, "utm");
+
     transform.header.frame_id = odom_frame;
     transform.child_frame_id = base_link_frame;
 
@@ -22,6 +26,11 @@ GPSOdom::GPSOdom(ros::NodeHandle& nh) :
 }
 
 void GPSOdom::updateFix(const sensor_msgs::NavSatFix::ConstPtr& fix) {
+    if ( isnan(fix->latitude) || isnan(fix->longitude) ) {
+        ROS_WARN("GPSOdom has no fix");
+        return;
+    }
+
     double northing, easting;
     std::string zone;
     gps_common::LLtoUTM(fix->latitude, fix->longitude, northing, easting, zone);

--- a/src/gps_odom/src/gps_odom.h
+++ b/src/gps_odom/src/gps_odom.h
@@ -5,19 +5,33 @@
 #include <sensor_msgs/NavSatFix.h>
 #include <sensor_msgs/Imu.h>
 #include <nav_msgs/Odometry.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <geometry_msgs/Vector3.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <tf2_ros/transform_broadcaster.h>
 
 class GPSOdom {
     public:
         GPSOdom(ros::NodeHandle &nh);
         void updateImu(const sensor_msgs::Imu::ConstPtr& imu);
         void updateFix(const sensor_msgs::NavSatFix::ConstPtr& fix);
+        void updateVel(const geometry_msgs::TwistStamped::ConstPtr& twist);
         void update();
     private:
         ros::Subscriber gpsSub;
         ros::Subscriber imuSub;
+        ros::Subscriber velSub;
+
         ros::Publisher odomPub;
+        tf2_ros::TransformBroadcaster transform_broadcaster;
 
         nav_msgs::Odometry odom_msg;
+        geometry_msgs::TransformStamped transform;
+
+        std::string base_link_frame;
+        std::string odom_frame;
+        std::string utm_frame;
+
         bool originSet;
         double originX, originY;
 };

--- a/src/gps_odom/src/gps_odom.h
+++ b/src/gps_odom/src/gps_odom.h
@@ -1,0 +1,26 @@
+#ifndef GPS_ODOM_H
+#define GPS_ODOM_H
+
+#include <ros/ros.h>
+#include <sensor_msgs/NavSatFix.h>
+#include <sensor_msgs/Imu.h>
+#include <nav_msgs/Odometry.h>
+
+class GPSOdom {
+    public:
+        GPSOdom(ros::NodeHandle &nh);
+        void updateImu(const sensor_msgs::Imu::ConstPtr& imu);
+        void updateFix(const sensor_msgs::NavSatFix::ConstPtr& fix);
+        void update();
+    private:
+        ros::Subscriber gpsSub;
+        ros::Subscriber imuSub;
+        ros::Publisher odomPub;
+
+        nav_msgs::Odometry odom_msg;
+        bool originSet;
+        double originX, originY;
+};
+
+#endif
+

--- a/src/gps_odom/src/gps_odom_node.cpp
+++ b/src/gps_odom/src/gps_odom_node.cpp
@@ -1,0 +1,18 @@
+#include <ros/ros.h>
+#include "gps_odom.h"
+
+
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "gps_odom");
+    ros::NodeHandle nh;
+
+    ros::Rate rate(10);
+
+    GPSOdom gps_odom(nh);
+
+    while ( nh.ok() ) {
+        gps_odom.update();
+        ros::spinOnce();
+        rate.sleep();
+    }
+}


### PR DESCRIPTION
Adds a gps_odom package which provides gps_odom_node. This node subscribes to the position and velocity estimates from the GPS (published by nmea_serial_driver in our current setup), as well as to the orientation from the IMU. This information is packed into an Odometry message and published as a tf2 transform. Position information is also converted into UTM using gps_common's conversions.h.