### PR TITLE
Standardize TF base_link frame

### DIFF
--- a/src/control_arduino/firmware/sailbot_motors/sailbot_motors.ino
+++ b/src/control_arduino/firmware/sailbot_motors/sailbot_motors.ino
@@ -118,7 +118,7 @@ void setup()
   
   bno.begin(Adafruit_BNO055::OPERATION_MODE_NDOF);
   
-  imu_msg.header.frame_id = "base_link";
+  imu_msg.header.frame_id = "boat";
 }
 
 void loop()

--- a/src/control_arduino/firmware/sailbot_motors_withRC/sailbot_motors_withRC.ino
+++ b/src/control_arduino/firmware/sailbot_motors_withRC/sailbot_motors_withRC.ino
@@ -126,7 +126,7 @@ void setup()
   
   bno.begin(Adafruit_BNO055::OPERATION_MODE_IMUPLUS);
   
-  imu_msg.header.frame_id = "base_link";
+  imu_msg.header.frame_id = "boat";
 }
 
 void loop()

--- a/src/sailbot_sim/README.md
+++ b/src/sailbot_sim/README.md
@@ -12,7 +12,7 @@ Simulates a boat that acts according to the simplified polar diagram presented i
 
 **Publishes:**
 * `odom` (Odometry) - The pose of the boat
-* `base_link -> odom` transform
+* `boat -> odom` transform
 
 **Services:**
 * `sim_reset_pose` - Resets the position and heading of the simulated boat to 0

--- a/src/sailbot_sim/scripts/sim_odom.py
+++ b/src/sailbot_sim/scripts/sim_odom.py
@@ -98,7 +98,7 @@ class OdomSim:
             odom.pose.pose.position = Vector3(self.x, self.y, 0)
             odom.pose.pose.orientation = Quaternion(headingQuat[0], headingQuat[1], headingQuat[2], headingQuat[3])
 
-            odom.child_frame_id = "base_link"
+            odom.child_frame_id = "boat"
 
             odom.twist.twist.linear = Vector3(velocity*cos(self.heading), velocity*sin(self.heading), 0)
             odom.twist.twist.angular = Vector3(0, 0, 0)
@@ -108,7 +108,7 @@ class OdomSim:
             self.tfBroadcaster.sendTransform((self.x, self.y, 0),
                                             headingQuat,
                                             now,
-                                            "base_link",
+                                            "boat",
                                             "odom");
 
             relative_wind_vector = self.calculateRelativeWindVector(odom.twist.twist.linear, self.windVector, self.heading)

--- a/src/sailbot_sim/scripts/wind_markers.py
+++ b/src/sailbot_sim/scripts/wind_markers.py
@@ -28,7 +28,7 @@ class WindMarkerPub:
 
         # Create relative wind marker for rviz
         self.relativeWindMarker = Marker()
-        self.relativeWindMarker.header.frame_id = "base_link"
+        self.relativeWindMarker.header.frame_id = "boat"
         self.relativeWindMarker.scale.x = 1
         self.relativeWindMarker.scale.y = 0.1
         self.relativeWindMarker.scale.z = 0.01

--- a/src/sailbot_sim/urdf/boat.urdf
+++ b/src/sailbot_sim/urdf/boat.urdf
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot name="sailbot">
-   <link name="base_link">
+   <link name="boat">
      <visual>
         <origin xyz="0 0 0.1" />
         <geometry>
@@ -20,7 +20,7 @@
 
 
   <joint name="base_to_sail" type="floating">
-    <parent link="base_link"/>
+    <parent link="boat"/>
     <child link="sail"/>
   </joint>
 </robot>

--- a/src/sensors/scripts/winddirection.py
+++ b/src/sensors/scripts/winddirection.py
@@ -20,7 +20,7 @@ class WindDirectionNode:
         self.tfBroadcaster = tf.TransformBroadcaster()
 
         self.relativeWindMarker = Marker()
-        self.relativeWindMarker.header.frame_id = "base_link"
+        self.relativeWindMarker.header.frame_id = "boat"
         self.relativeWindMarker.scale.x = 1 
         self.relativeWindMarker.scale.y = 0.1 
         self.relativeWindMarker.scale.z = 0.01 


### PR DESCRIPTION
Standardize TF frames across the stack. Localization development has used `boat` as the base TF frame, while everything else in the stack uses `base_link`. This isn't currently documented in the design doc, so if we want to use `base_link` instead I can update this PR.