### PR TITLE
Add getter for actual position on teensy firmware

### DIFF
--- a/src/control_arduino/firmware/sailbot_controller/PIDSubsystem.cpp
+++ b/src/control_arduino/firmware/sailbot_controller/PIDSubsystem.cpp
@@ -61,10 +61,15 @@ void PIDSubsystem::updateDTerm(const std_msgs::Float64& dTerm) {
     pid.configD(dTerm.data);
 }
 
+double PIDSubsystem::getActual() {
+    return actualPosition;
+}
+
 void PIDSubsystem::update() {
     if ( !controlActive )
         return;
     int actual = analogRead(analogSensorPin);
+    actualPosition = (actual-adcOffset) / adcConversion;
     double output = pid.calculate(actual);
     pwm.set(output);
 }

--- a/src/control_arduino/firmware/sailbot_controller/PIDSubsystem.h
+++ b/src/control_arduino/firmware/sailbot_controller/PIDSubsystem.h
@@ -18,6 +18,8 @@ public:
     void setSetpoint(double setpoint);
     void setOpenLoop(double speed);
 
+    double getActual();
+
     void update();
 private:
     ros::NodeHandle* nh;
@@ -32,6 +34,7 @@ private:
     void updateITerm(const std_msgs::Float64& iTerm);
     void updateDTerm(const std_msgs::Float64& dTerm);
 
+    double actualPosition;
     ros::Subscriber<std_msgs::Float64, PIDSubsystem>* pConfigSub;
     ros::Subscriber<std_msgs::Float64, PIDSubsystem>* iConfigSub;
     ros::Subscriber<std_msgs::Float64, PIDSubsystem>* dConfigSub;


### PR DESCRIPTION
This PR adds a getter for the PIDSubsystem class that gets the current "actual" sensor position in converted units.
